### PR TITLE
Idea for reorganization

### DIFF
--- a/lib/harald/error_code.ex
+++ b/lib/harald/error_code.ex
@@ -88,12 +88,20 @@ defmodule Harald.ErrorCode do
   Enum.each(@error_codes, fn
     {error_code, name} ->
       def name(unquote(error_code)), do: {:ok, unquote(name)}
+      def name!(unquote(error_code)), do: unquote(name)
       def error_code(unquote(name)), do: {:ok, unquote(error_code)}
+      def error_code!(unquote(name)), do: unquote(error_code)
   end)
 
   def name(_), do: :error
 
+  def name!(error_code),
+    do: raise("[#{inspect(__MODULE__)}] Unabled to get name for #{inspect(error_code)}")
+
   def error_code(_), do: :error
+
+  def error_code!(name),
+    do: raise("[#{inspect(__MODULE__)}] Unabled to get error_code for #{inspect(name)}")
 
   def all, do: @error_codes
 end

--- a/lib/harald/hci/command.ex
+++ b/lib/harald/hci/command.ex
@@ -1,0 +1,45 @@
+defmodule Harald.HCI.Command do
+  @callback return_parameters(binary()) :: map() | binary()
+  @callback deserialize(binary()) :: {:ok, term()} | {:error, term()}
+
+  @modules [
+    Harald.HCI.Command.ControllerAndBaseband.ReadLocalName
+  ]
+
+  def __modules__(), do: @modules
+
+  defmacro defparameters(fields) when is_list(fields) do
+    fields =
+      if Keyword.keyword?(fields) do
+        fields
+      else
+        for key <- fields, do: {key, nil}
+      end
+
+    quote location: :keep, bind_quoted: [fields: fields] do
+      # This is odd, but defparameters/1 is only intended to be used
+      # in modules with Harald.HCI.Command.__using__/1 macro which will
+      # have these attributes defined. If not, let it fail
+      fields = Keyword.merge(fields, ogf: @ogf, ocf: @ocf, opcode: @opcode)
+      defstruct fields
+    end
+  end
+
+  defmacro __using__(opts) do
+    quote location: :keep, bind_quoted: [opts: opts] do
+      ogf =
+        Keyword.get_lazy(opts, :ogf, fn ->
+          raise ":ogf key required when defining HCI.Command.__using__/1"
+        end)
+
+      @behaviour Harald.HCI.Command
+      import Harald.HCI.Command, only: [defparameters: 1]
+
+      @ogf ogf
+
+      def __ogf__(), do: @ogf
+
+      def new(args \\ []), do: struct(__MODULE__, args)
+    end
+  end
+end

--- a/lib/harald/hci/commands/controller_and_baseband.ex
+++ b/lib/harald/hci/commands/controller_and_baseband.ex
@@ -1,0 +1,47 @@
+defmodule Harald.HCI.Command.ControllerAndBaseband do
+  alias __MODULE__, as: CaB
+  @ogf 0x03
+
+  @moduledoc """
+  HCI commands for working with the controller and baseband.
+
+  * OGF: `#{inspect(@ogf, base: :hex)}`
+
+  > The Controller & Baseband Commands provide access and control to various capabilities of the
+  > Bluetooth hardware. These parameters provide control of BR/EDR Controllers and of the
+  > capabilities of the Link Manager and Baseband in the BR/EDR Controller, the PAL in an AMP
+  > Controller, and the Link Layer in an LE Controller. The Host can use these commands to modify
+  > the behavior of the local Controller.
+  Bluetooth Spec v5
+  """
+
+  def __ogf__(), do: @ogf
+
+  @doc """
+  List all available controller and baseband command modules
+  """
+  @spec list :: [module()]
+  def list() do
+    Application.spec(:harald, :modules)
+    |> Enum.filter(
+      &match?(["Harald", "HCI", "Command", "ControllerAndBaseband", _mod], Module.split(&1))
+    )
+  end
+
+  defmacro __using__(opts) do
+    quote location: :keep, bind_quoted: [opts: opts] do
+      ocf =
+        Keyword.get_lazy(opts, :ocf, fn ->
+          raise ":ocf key required when defining HCI.Command.ControllerAndBaseband.__using__/1"
+        end)
+
+      use Harald.HCI.Command, Keyword.put(opts, :ogf, CaB.__ogf__())
+
+      @ocf ocf
+      @opcode Harald.HCI.opcode(CaB.__ogf__(), @ocf)
+
+      def __ocf__(), do: @ocf
+      def __opcode__(), do: @opcode
+    end
+  end
+end

--- a/lib/harald/hci/commands/controller_and_baseband/read_local_name.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/read_local_name.ex
@@ -1,0 +1,45 @@
+defmodule Harald.HCI.Command.ControllerAndBaseband.ReadLocalName do
+  use Harald.HCI.Command.ControllerAndBaseband, ocf: 0x0014
+
+  @moduledoc """
+  The Read_Local_Name command provides the ability to read the stored user-friendly name for
+  the BR/EDR Controller. See Section 6.23 and 7.3.12 for more details
+
+  * OGF: `#{inspect(@ogf, base: :hex)}`
+  * OCF: `#{inspect(@ocf, base: :hex)}`
+  * Opcode: `#{inspect(@opcode)}`
+
+  ## Command Parameters
+  > None
+
+  ## Return Parameters
+  * `:status` - see `Harald.ErrorCode`
+  * `:local_name` - A UTF-8 encoded User Friendly Descriptive Name for the device
+  """
+
+  defparameters([])
+
+  defimpl HCI.Serializable do
+    def serialize(%{opcode: opcode}) do
+      <<opcode::binary, 0::8, "">>
+    end
+  end
+
+  @impl true
+  def deserialize(<<@opcode::binary, 0::8, "">>) do
+    # This is a pretty useless function because there aren't
+    # any parameters to actually parse out of this, but we
+    # can at least assert its correct with matching
+    {:ok, %__MODULE__{}}
+  end
+
+  @impl true
+  def return_parameters(<<status::8, local_name::binary>>) do
+    %{
+      status: Harald.ErrorCode.name!(status),
+      # The local name field will fill any remainder of the
+      # 248 bytes with null bytes. So just trim those.
+      local_name: String.trim(local_name, <<0>>)
+    }
+  end
+end

--- a/lib/harald/protocols.ex
+++ b/lib/harald/protocols.ex
@@ -4,3 +4,57 @@ defprotocol HCI.Serializable do
   """
   def serialize(hci_struct)
 end
+
+defprotocol HCI.Deserializable do
+  @doc """
+  Deserialize a binary into HCI data structures
+  """
+  def deserialize(bin)
+end
+
+defprotocol HCI.CommandComplete.ReturnParameters do
+  @doc """
+  Protocol for handling command return_parameters in CommandComplete event
+
+  This is mainly to allow us to do function generation at compile time
+  for handling this parsing for specific commands.
+  """
+  def parse(cc_struct)
+end
+
+defimpl HCI.Deserializable, for: BitString do
+  # Define deserialize/1 for HCI.Command modules
+  for mod <- Harald.HCI.Command.__modules__(), opcode = mod.__opcode__() do
+    def deserialize(unquote(opcode) <> _ = bin) do
+      unquote(mod).deserialize(bin)
+    end
+  end
+
+  def deserialize(bin) do
+    error = """
+    Unable to deserialize #{inspect(bin)}
+
+    If this is unexpected, then be sure that the target deserialized module
+    is defined in the @modules attribute of the appropiate type:
+
+    * Harald.HCI.Command
+    * Harald.HCI.Event
+    """
+
+    {:error, error}
+  end
+end
+
+defimpl HCI.CommandComplete.ReturnParameters, for: Harald.HCI.Event.CommandComplete do
+  def parse(cc) do
+    %{cc | return_parameters: do_parse(cc.opcode, cc.return_parameters)}
+  end
+
+  # Generate return_parameter parsing function for all available command
+  # modules based on the requirements in Harald.HCI.Command behaviour
+  for mod <- Harald.HCI.Command.__modules__(), opcode = mod.__opcode__() do
+    defp do_parse(unquote(opcode), rp_bin) do
+      unquote(mod).return_parameters(rp_bin)
+    end
+  end
+end

--- a/lib/harald/protocols.ex
+++ b/lib/harald/protocols.ex
@@ -1,0 +1,6 @@
+defprotocol HCI.Serializable do
+  @doc """
+  Serialize an HCI data structure as a binary
+  """
+  def serialize(hci_struct)
+end


### PR DESCRIPTION
An idea for organizing harald to conform more to how the spec is organized. The hope is to also make adding support for a command/event as easy as just adding a new module that matches some behaviour expectations.

This only applies this idea to `Read_Local_Name` command from `ControllerAndBaseband` section. If we like this idea, we can move forward with the organization

Here is a picture of the spec outline to shed a little light on why I was going this route. Essentially, commands conform to `Harald.HCI.Command` behavior. And each command section has a specific OGF, which is placed in a higher order module (i.e. `ControllerAndBaseband`). Then in this structure, the simple task of combining a commands `OCF` and `OGF` base is handled by just _using_ their base module. Each command module only needs to define how it specifically serializes, deserializes, and if it should parse `return_parameters` for a `CommandComplete` event.
![image](https://user-images.githubusercontent.com/11321326/90326992-7617c800-df4c-11ea-8e2c-770c61b3b642.png)
